### PR TITLE
Fix build on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ add something like this to your Gemfile:
 
 ```ruby
 gem "kyotocabinet-ruby", "~> 1.27.1", :platforms => [:mri, :rbx]
-gem "kyotocabinet-java", "~> 0.2.0", :platforms => :jruby
+gem "kyotocabinet-java", "~> 0.3.0", :platforms => :jruby
 ```
 
 ## Usage

--- a/ext/kyotocabinet-java/configure
+++ b/ext/kyotocabinet-java/configure
@@ -1834,7 +1834,7 @@ then
 else
   if uname | grep Darwin >config.tmp; then
     # Mac OS X
-    MYJAVAHOME=/System/Library/Frameworks/JavaVM.framework
+    MYJAVAHOME=`/usr/libexec/java_home`
   elif test -L /usr/bin/javac; then
     # other Unix, but /usr/bin/javac is a symlink
     MYJAVAHOME=`readlink -f /usr/bin/javac | sed "s:bin/javac::"`

--- a/ext/kyotocabinet-java/configure
+++ b/ext/kyotocabinet-java/configure
@@ -1844,18 +1844,14 @@ printf '%s\n' "$MYJAVAHOME"
 
 # Platform of Java
 printf 'checking JVMPLATFORM... '
-if uname | grep Darwin >config.tmp
-then
-  JVMPLATFORM="mac"
-else
-  for file in `\ls $MYJAVAHOME/include`
-  do
-    if test -d "$MYJAVAHOME/include/$file"
-    then
-      JVMPLATFORM="$file"
-    fi
-  done
-fi
+for file in `\ls $MYJAVAHOME/include`
+do
+  if test -d "$MYJAVAHOME/include/$file"
+  then
+    JVMPLATFORM="$file"
+  fi
+done
+
 printf '%s\n' "$JVMPLATFORM"
 MYCPPFLAGS="$MYCPPFLAGS -I$MYJAVAHOME/include -I$MYJAVAHOME/include/$JVMPLATFORM"
 MYCPPFLAGS="$MYCPPFLAGS -I$MYJAVAHOME/Headers -I$MYJAVAHOME/Headers/$JVMPLATFORM"


### PR DESCRIPTION
Currently there's a default JAVA_HOME that doesn't work on at least `10.11` and `10.12` (but I'm pretty sure 10.10 is broken too), it also sets JVM_PLATFORM to `mac` but the correct value is now `darwin`.

This changes the configuration script to fix both of these, it also changes the `README.md` to link to the latest version.
